### PR TITLE
fix: (popup) shortcuts not shown in some cases

### DIFF
--- a/src/popup/script.js
+++ b/src/popup/script.js
@@ -299,7 +299,7 @@ const pop = {
 
         let shortcutsData = pop.currentWebsiteShortcutsData
 
-        for (const key in shortcutsData) {
+        for (let key in shortcutsData) {
             if (Object.hasOwnProperty.call(shortcutsData, key)) {
                 let shortcutDiv = templateElement.content.cloneNode(true)
 
@@ -366,7 +366,19 @@ const pop = {
                 })
 
                 shortcutsListDiv.appendChild(shortcutDiv)
-                let shortcutEnableDisableToggle = shortcutsListDiv.querySelector(`.shortcutEnableDisableToggle-wrapper .toggleSwitchInput[data-shortcutKey='${key}']`)
+                let shortcutEnableDisableToggle;
+                if (key=='"') {
+                    shortcutEnableDisableToggle = shortcutsListDiv.querySelector(`.shortcutEnableDisableToggle-wrapper .toggleSwitchInput[data-shortcutkey='${key}']`)
+                }
+                else if (key=="\\") {
+                    shortcutEnableDisableToggle = shortcutsListDiv.querySelector(`.shortcutEnableDisableToggle-wrapper .toggleSwitchInput[data-shortcutkey="\\${key}"]`)
+                }
+                else{
+                    shortcutEnableDisableToggle = shortcutsListDiv.querySelector(`.shortcutEnableDisableToggle-wrapper .toggleSwitchInput[data-shortcutkey="${key}"]`)
+                }
+
+
+                
 
                 setEvent(shortcutEnableDisableToggle, "click", (e) => {
                     pop.enableDisableForShortcut(e, shortcutEnableDisableToggle, urlOfShortcut)


### PR DESCRIPTION
## Describe the changes

If some special chars like slash or double inverted comma are one of the available shorcuts in a website, then the popup doesn't show all the shortcuts and throws error. None of the buttons work like options page, etc.

## Related Issues

fixes #46 


## Recording

https://github.com/mywebshortcuts/mywebshortcuts/assets/65062036/c4c58152-ecd5-474d-8f64-3b1a4a14ee53

