### PR TITLE
Improving Selectors

### DIFF
--- a/src/scripts/setter.js
+++ b/src/scripts/setter.js
@@ -565,39 +565,54 @@ const mws = {
         await sendMsg({ msg: "selectorDisabled", spread: true })
     },
 
+    keyPressed : false,
     pauseResumeSelection: (e) => {
         if (mws.currentState.elementSelectionOn) {
-            // e.preventDefault()
-            // // console.log(e);
+            
             if (e.type == "keydown") {
-                // keyCode of both ControlLeft and ControlRight is 17, bcoz obv both are Control keys
-                if (e.keyCode == 17) {
-                    if (mws.currentState.elementSelectionPaused) {
-                        window.addEventListener('mouseover', mws.addRemoveborder);
-                        mws.currentState.elementSelectionPaused = false
-                        qS(".mws-disableElementSelectionSpan").innerText = (qS(".mws-disableElementSelectionSpan").innerText).replace(' (Paused)', '')
-                        mws.playSoundEffect('unpause', 0.2)
-                        // qS('.mws-selectElementButton').style.display = 'none'
-                        updateCSS(qS('.mws-selectElementButton'), { display: "none !important" })
-                        // // console.log(qS('.mws-element button.mws-selectElementButton').style.display);
+                
+                if (e.key == "Control" || e.key == "Meta") {
+                    mws.keyPressed = true
+                    console.log("Presed ctrl, ");
+
+                    setTimeout(() => {
+
+                        if (mws.keyPressed) {
+                            console.log(mws.keyPressed);
+                        
+                            if (mws.currentState.elementSelectionPaused) {
+                                window.addEventListener('mouseover', mws.addRemoveborder);
+                                mws.currentState.elementSelectionPaused = false
+                                qS(".mws-disableElementSelectionSpan").innerText = (qS(".mws-disableElementSelectionSpan").innerText).replace(' (Paused)', '')
+                                mws.playSoundEffect('unpause', 0.2)
+                                // qS('.mws-selectElementButton').style.display = 'none'
+                                updateCSS(qS('.mws-selectElementButton'), { display: "none !important" })
+                                // // console.log(qS('.mws-element button.mws-selectElementButton').style.display);
+                            }
+                            else {
+                                // qS('.mws-element button.mws-selectElementButton').style.display = 'flex'
+                                updateCSS(qS('.mws-selectElementButton'), { display: "flex !important" })
+                                // console.log(qS('.mws-selectElementButton').style.display);
+                                mws.playSoundEffect('pause', 0.2)
+                                window.removeEventListener('mouseover', mws.addRemoveborder);
+                                mws.currentState.elementSelectionPaused = true
+                                qS(".mws-disableElementSelectionSpan").innerText = qS(".mws-disableElementSelectionSpan").innerText + " (Paused)"
+                            }
                     }
-                    else {
-                        // qS('.mws-element button.mws-selectElementButton').style.display = 'flex'
-                        updateCSS(qS('.mws-selectElementButton'), { display: "flex !important" })
-                        // console.log(qS('.mws-selectElementButton').style.display);
-                        mws.playSoundEffect('pause', 0.2)
-                        window.removeEventListener('mouseover', mws.addRemoveborder);
-                        mws.currentState.elementSelectionPaused = true
-                        qS(".mws-disableElementSelectionSpan").innerText = qS(".mws-disableElementSelectionSpan").innerText + " (Paused)"
-                    }
+
+                    }, 1000);
+
                 }
 
             }
-            // if (e.type == "keyup") {
-            //     if (e.keyCode == 17) {
-            //         window.addEventListener('mouseover', mws.addRemoveborder);
-            //     }
-            // }
+            
+            if(e.type == "keyup"){
+                if (e.key == "Control" || e.key == "Meta") {
+                    console.log("It's keyup of control, falsing");
+                    mws.keyPressed = false
+                    console.log(mws.keyPressed);
+                }
+            }
 
         }
     },
@@ -1185,6 +1200,7 @@ const mws = {
         window.removeEventListener('mouseover', mws.addRemoveborder);
         window.removeEventListener('click', mws.whenClicked);
         window.removeEventListener('keydown', mws.pauseResumeSelection)
+        window.removeEventListener('keyup', mws.pauseResumeSelection)
 
 
         mws.changeStateAndUpdateDOM("elementSelectionOn")
@@ -1198,6 +1214,7 @@ const mws = {
         window.addEventListener('mouseover', mws.addRemoveborder);
         window.addEventListener('click', mws.whenClicked);
         window.addEventListener('keydown', mws.pauseResumeSelection)
+        window.addEventListener('keyup', mws.pauseResumeSelection)
 
     },
     // The function to trigger switchOnSelector or switchOffSelector depending on mws.currentState.elementSelectionOn

--- a/src/scripts/setter.js
+++ b/src/scripts/setter.js
@@ -372,7 +372,8 @@ const mws = {
                 urlType: mws.selectedURLType
             },
 
-            selected: { cssSelector: finder(mws.currentElement) },
+            // selected: { cssSelector: finder(mws.currentElement, { seedMinLength:5 , attr : (name, value)=>{return true}}) },
+            selected: { cssSelector: mws.selectedElement},
         }
 
 
@@ -720,7 +721,10 @@ const mws = {
     },
 
     openKeyboardShortcutSelectionDialog: async function () {
-        mws.selectedElement = mws.currentElement
+        // mws.selectedElement = mws.currentElement
+        // mws.selectedElement = finder((mws.currentElement), { seedMinLength: 5, attr: (name, value) => { return true } })
+        mws.selectedElement = finder(mws.currentElement)
+        mws.selectedElement = (mws.selectedElement).replace('mws-bordered', '')
 
         mws.turnOnKeyboardEvents()
 

--- a/src/scripts/useCustomShortcut.js
+++ b/src/scripts/useCustomShortcut.js
@@ -422,6 +422,7 @@ const ucs = {
 
         } else {
             // console.log("Element not found on the page.");
+            alert("Element was not found - My Web Shortcuts")
             return false
         }
     },


### PR DESCRIPTION
## Describe the changes

**The Keyselector is unable to save the element**
While selecting an element, if the element was removed from the DOM then the user was unable to save it and the Adding shortcut text stayed inside the Add Shortcut button forever. Now it's solved and gets the selector before doing anything else.

**Press and hold ctrl to pause element selection**
Previously, pressing the ctrl key was used to immediately pause the element selection, which was annoying. So now the user
needs to press and hold CTRL for 1 sec to pause element selection.
The Command key not working in Mac is also solved (hopefully).

**Other changes**
UCS Alerts when an element is not found

## Related Issues

fixes #48 #49


